### PR TITLE
expose mongoCollectionFunctions

### DIFF
--- a/MongoCollection.js
+++ b/MongoCollection.js
@@ -66,3 +66,4 @@ mongoCollectionFunctions.forEach((fnName) => {
 });
 
 module.exports = Flint.Component.define(MongoCollection);
+module.exports.commands = mongoCollectionFunctions.slice();


### PR DESCRIPTION
Expose the list of functions available.
the name commands is used to be consistent with the redis flint component.